### PR TITLE
T.1.4: Modeling layer extensions — LLM provider agnosticism, WSClient streaming, LLMJudge thresholds

### DIFF
--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -62,14 +62,19 @@ Tasks are ordered by dependency. Each task has acceptance criteria and a validat
 
 **Validation**: `pytest src/test/python/ut/ -v` — all plugin discovery and basic operations pass
 
-### T.1.4 — Modeling Layer Extensions
+### T.1.4 — Modeling Layer Extensions (Done)
 
-| Model | Location | Wraps |
-|-------|----------|-------|
-| `WSClient` | `taf/modeling/ws/` | `WSPlugin` — async context manager for WebSocket streaming |
-| `LLMJudge` | `taf/modeling/llm/` | `LLMPlugin` — rubric-based scoring with configurable dimensions |
-
-**Validation**: Unit tests for WSClient and LLMJudge pass
+- [x] LLMClient refactored for provider agnosticism:
+  - `provider='openai'` (default): uses `langchain-openai` ChatOpenAI — works with OpenAI, OpenRouter, local LLMs (Ollama, vLLM), SSO endpoints
+  - `provider='anthropic'`: uses `langchain-anthropic` ChatAnthropic
+  - Configurable via `TAF_LLM_PROVIDER` env var, `base_url`, `api_key` kwargs
+  - Lazy imports — only loads the selected provider's SDK
+  - Removed hard `ChatAnthropic` coupling from T.1.3
+- [x] WSClient enhanced: `collect()` (batch receive), `collect_text()` (concatenate stream), `send_and_receive()` (request-response)
+- [x] LLMJudge enhanced: `assert_quality()` with configurable `overall_threshold`, `dimension_thresholds`, `fail_any_below` floor — raises `AssertionError` with details on failure
+- [x] pyproject.toml: `llm` group now uses `langchain-openai` (default); separate `llm-anthropic` and `llm-all` groups
+- [x] 20 new unit tests (109 total); LLM tests cover both OpenAI and Anthropic providers
+- [x] Validation: flake8 0, mypy 0 (141 files), pytest 109 passed
 
 ### T.1.5 — Chaos Module
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,12 +33,15 @@ appium = ["Appium-Python-Client>=4.0"]
 playwright = ["playwright>=1.40"]
 httpx = ["httpx>=0.27"]
 websocket = ["websockets>=12.0"]
-llm = ["langchain-anthropic>=0.3"]
+llm = ["langchain-openai>=0.3"]
+llm-anthropic = ["langchain-anthropic>=0.3"]
+llm-all = ["langchain-openai>=0.3", "langchain-anthropic>=0.3"]
 all = [
     "Appium-Python-Client>=4.0",
     "playwright>=1.40",
     "httpx>=0.27",
     "websockets>=12.0",
+    "langchain-openai>=0.3",
     "langchain-anthropic>=0.3",
 ]
 dev = [

--- a/src/main/python/taf/foundation/api/llm/client.py
+++ b/src/main/python/taf/foundation/api/llm/client.py
@@ -20,14 +20,23 @@ class Client:
         'safety': 'No harmful, biased, or leaked information',
     }
 
+    PROVIDER_OPENAI = 'openai'
+    PROVIDER_ANTHROPIC = 'anthropic'
+
     def __init__(
             self,
             model: str | None = None,
             rubric: dict[str, str] | None = None,
+            provider: str = PROVIDER_OPENAI,
+            base_url: str | None = None,
+            api_key: str | None = None,
             **kwargs
     ):
         self.model = model
         self.rubric = rubric or self.DEFAULT_RUBRIC
+        self.provider = provider
+        self.base_url = base_url
+        self.api_key = api_key
         self.params = kwargs
 
     def evaluate(

--- a/src/main/python/taf/foundation/plugins/llm/judge/__init__.py
+++ b/src/main/python/taf/foundation/plugins/llm/judge/__init__.py
@@ -13,5 +13,6 @@
 try:
     from taf.foundation.plugins.llm.judge.llmclient import LLMClient  # noqa: F401
 except ImportError:
-    # langchain-anthropic not installed — plugin will be skipped by ServiceLocator
+    # langchain-openai or langchain-anthropic not installed —
+    # plugin will be skipped by ServiceLocator
     pass

--- a/src/main/python/taf/foundation/plugins/llm/judge/llmclient.py
+++ b/src/main/python/taf/foundation/plugins/llm/judge/llmclient.py
@@ -11,25 +11,87 @@
 # GNU Lesser General Public License for more details.
 
 import json
-
-from langchain_anthropic import ChatAnthropic
+import os
+from typing import Any
 
 from taf.foundation.api.llm import Client
 
 
+def _create_chat_model(
+        provider: str,
+        model: str,
+        base_url: str | None = None,
+        api_key: str | None = None,
+        **kwargs
+) -> Any:
+    """Create a LangChain chat model based on provider.
+
+    Supports:
+      - 'openai': langchain-openai ChatOpenAI (also works with
+        OpenAI-compatible APIs like local LLMs, OpenRouter, vLLM)
+      - 'anthropic': langchain-anthropic ChatAnthropic
+    """
+    if provider == Client.PROVIDER_ANTHROPIC:
+        from langchain_anthropic import ChatAnthropic
+        init_kwargs: dict[str, Any] = {
+            'model_name': model,
+            'temperature': kwargs.get('temperature', 0.0),
+        }
+        if api_key:
+            init_kwargs['anthropic_api_key'] = api_key
+        return ChatAnthropic(**init_kwargs)
+
+    # Default: OpenAI-compatible (works with OpenAI, OpenRouter,
+    # local LLMs, vLLM, etc.)
+    from langchain_openai import ChatOpenAI
+    init_kwargs = {
+        'model': model,
+        'temperature': kwargs.get('temperature', 0.0),
+        'max_tokens': kwargs.get('max_tokens', 1024),
+    }
+    if base_url:
+        init_kwargs['base_url'] = base_url
+    if api_key:
+        init_kwargs['api_key'] = api_key
+    return ChatOpenAI(**init_kwargs)
+
+
 class LLMClient(Client):
+    DEFAULT_MODELS = {
+        Client.PROVIDER_OPENAI: 'gpt-4o-mini',
+        Client.PROVIDER_ANTHROPIC: 'claude-sonnet-4-20250514',
+    }
+
     def __init__(
             self,
             model: str | None = None,
             rubric: dict[str, str] | None = None,
+            provider: str | None = None,
+            base_url: str | None = None,
+            api_key: str | None = None,
             **kwargs
     ):
-        super().__init__(model, rubric, **kwargs)
+        _provider = (
+            provider
+            or os.environ.get('TAF_LLM_PROVIDER', Client.PROVIDER_OPENAI)
+        )
+        _model = model or self.DEFAULT_MODELS.get(
+            _provider, 'gpt-4o-mini'
+        )
 
-        self._llm = ChatAnthropic(
-            model_name=self.model or 'claude-sonnet-4-20250514',
-            temperature=kwargs.get('temperature', 0.0),
-            max_tokens=kwargs.get('max_tokens', 1024),  # type: ignore[call-arg]
+        super().__init__(
+            _model, rubric,
+            provider=_provider,
+            base_url=base_url,
+            api_key=api_key,
+            **kwargs
+        )
+
+        self._llm = _create_chat_model(
+            self.provider, self.model or _model,
+            base_url=self.base_url,
+            api_key=self.api_key,
+            **kwargs
         )
 
     def evaluate(
@@ -39,7 +101,7 @@ class LLMClient(Client):
             context: dict | None = None,
             **kwargs
     ) -> dict:
-        scores = {}
+        scores: dict[str, float] = {}
         for dimension in self.rubric:
             scores[dimension] = self.score(
                 prompt, response, dimension,

--- a/src/main/python/taf/modeling/llm/llmjudge.py
+++ b/src/main/python/taf/modeling/llm/llmjudge.py
@@ -14,17 +14,86 @@ from taf.foundation.api.llm import Client
 
 
 class LLMJudge(Client):
-    """High-level LLM-as-judge evaluator.
+    """High-level LLM-as-judge evaluator with threshold assertions.
 
-    Usage via ServiceLocator when LLMPlugin is enabled in config,
-    or directly for standalone LLM testing:
+    Supports both OpenAI-compatible and Anthropic providers::
 
-        judge = LLMJudge(model='claude-sonnet-4-20250514')
-        scores = judge.evaluate(
+        # OpenAI-compatible (default) — works with local LLMs, OpenRouter
+        judge = LLMJudge(
+            model='gpt-4o-mini',
+            provider='openai',
+            base_url='http://localhost:11434/v1',  # e.g. Ollama
+        )
+
+        # Anthropic
+        judge = LLMJudge(
+            model='claude-sonnet-4-20250514',
+            provider='anthropic',
+        )
+
+        # Evaluate with threshold
+        result = judge.assert_quality(
             prompt='What environments are running?',
             response='Currently there are 3 active environments...',
-            context={'actual_count': 3}
+            context={'actual_count': 3},
+            overall_threshold=3.5,
+            dimension_thresholds={'accuracy': 4.0},
         )
-        assert scores['accuracy'] >= 4.0
     """
-    pass
+
+    def assert_quality(
+            self,
+            prompt: str,
+            response: str,
+            context: dict | None = None,
+            overall_threshold: float = 3.5,
+            dimension_thresholds: dict[str, float] | None = None,
+            fail_any_below: float | None = 2.0,
+    ) -> dict:
+        """Evaluate and raise AssertionError if thresholds not met.
+
+        Args:
+            prompt: The user prompt that was sent
+            response: The AI response to evaluate
+            context: Ground truth data for comparison
+            overall_threshold: Minimum overall score (default 3.5)
+            dimension_thresholds: Per-dimension minimum scores
+            fail_any_below: Fail if ANY dimension scores below this
+
+        Returns:
+            dict with dimension scores + 'overall' + 'passed' bool
+
+        Raises:
+            AssertionError with details if thresholds not met
+        """
+        scores = self.evaluate(prompt, response, context=context)
+        failures: list[str] = []
+
+        if scores['overall'] < overall_threshold:
+            failures.append(
+                f"overall {scores['overall']:.2f} < {overall_threshold}"
+            )
+
+        if fail_any_below is not None:
+            for dim, val in scores.items():
+                if dim != 'overall' and val < fail_any_below:
+                    failures.append(
+                        f"{dim} {val:.2f} < {fail_any_below} (floor)"
+                    )
+
+        if dimension_thresholds:
+            for dim, threshold in dimension_thresholds.items():
+                if dim in scores and scores[dim] < threshold:
+                    failures.append(
+                        f"{dim} {scores[dim]:.2f} < {threshold}"
+                    )
+
+        scores['passed'] = len(failures) == 0
+
+        if failures:
+            raise AssertionError(
+                f"LLM quality check failed: {'; '.join(failures)}\n"
+                f"Scores: {scores}"
+            )
+
+        return scores

--- a/src/main/python/taf/modeling/ws/wsclient.py
+++ b/src/main/python/taf/modeling/ws/wsclient.py
@@ -14,13 +14,52 @@ from taf.foundation.api.ws import Client
 
 
 class WSClient(Client):
-    """High-level WebSocket client.
+    """High-level WebSocket client with streaming support.
 
-    Usage via ServiceLocator when WSPlugin is enabled in config,
-    or directly for standalone WebSocket testing:
+    Usage::
 
         with WSClient('ws://localhost:8080/ws') as ws:
-            ws.send({'type': 'ping'})
-            response = ws.receive(timeout=5)
+            ws.send({'type': 'chat', 'message': 'hello'})
+
+            # Collect all messages until timeout
+            messages = ws.collect(timeout=5)
+
+            # Or iterate token-by-token
+            ws.send({'type': 'stream'})
+            full = ws.collect_text(timeout=10)
     """
-    pass
+
+    def collect(
+            self,
+            timeout: float = 5.0,
+            max_messages: int = 100,
+    ) -> list[str]:
+        """Receive messages until timeout or max_messages reached."""
+        messages: list[str] = []
+        for _ in range(max_messages):
+            try:
+                msg = self.receive(timeout=timeout)
+                messages.append(msg)
+            except Exception:
+                break
+        return messages
+
+    def collect_text(
+            self,
+            timeout: float = 5.0,
+            max_messages: int = 100,
+            separator: str = '',
+    ) -> str:
+        """Receive messages and concatenate into a single string."""
+        return separator.join(
+            self.collect(timeout=timeout, max_messages=max_messages)
+        )
+
+    def send_and_receive(
+            self,
+            message: str | dict,
+            timeout: float = 10.0,
+    ) -> str:
+        """Send a message and return the first response."""
+        self.send(message)
+        return self.receive(timeout=timeout)

--- a/src/test/python/ut/test_llm_plugin.py
+++ b/src/test/python/ut/test_llm_plugin.py
@@ -15,23 +15,46 @@ from unittest import TestCase, skipUnless
 from unittest.mock import patch, MagicMock
 
 from taf.foundation.api.plugins import LLMPlugin
+from taf.foundation.api.llm import Client as LLMBaseClient
 
-_has_langchain = importlib.util.find_spec('langchain_anthropic') is not None
+_has_langchain_openai = importlib.util.find_spec('langchain_openai') is not None
+_has_langchain_anthropic = importlib.util.find_spec('langchain_anthropic') is not None
+_has_any_langchain = _has_langchain_openai or _has_langchain_anthropic
+
+
+class TestLLMBaseClientProviders(TestCase):
+    """Tests for LLM base client provider constants."""
+
+    def test_provider_constants(self):
+        self.assertEqual(LLMBaseClient.PROVIDER_OPENAI, 'openai')
+        self.assertEqual(LLMBaseClient.PROVIDER_ANTHROPIC, 'anthropic')
+
+    def test_init_with_provider(self):
+        client = LLMBaseClient(provider='anthropic')
+        self.assertEqual(client.provider, 'anthropic')
+
+    def test_init_with_base_url(self):
+        client = LLMBaseClient(base_url='http://localhost:11434/v1')
+        self.assertEqual(client.base_url, 'http://localhost:11434/v1')
+
+    def test_init_default_provider_is_openai(self):
+        client = LLMBaseClient()
+        self.assertEqual(client.provider, 'openai')
 
 
 class TestLLMJudgePlugin(TestCase):
     """Tests for LLMJudgePlugin registration and client property."""
 
-    @skipUnless(_has_langchain, 'langchain-anthropic not installed')
+    @skipUnless(_has_any_langchain, 'langchain not installed')
     def test_is_subclass_of_llmplugin(self):
         from taf.foundation.plugins.llm.judge.llmjudgeplugin import LLMJudgePlugin
         self.assertTrue(issubclass(LLMJudgePlugin, LLMPlugin))
 
-    @skipUnless(_has_langchain, 'langchain-anthropic not installed')
+    @skipUnless(_has_any_langchain, 'langchain not installed')
     def test_registered_in_plugins(self):
         self.assertIn('llmjudgeplugin', LLMPlugin.plugins)
 
-    @skipUnless(_has_langchain, 'langchain-anthropic not installed')
+    @skipUnless(_has_any_langchain, 'langchain not installed')
     def test_client_returns_llmclient(self):
         from taf.foundation.plugins.llm.judge.llmjudgeplugin import LLMJudgePlugin
         from taf.foundation.plugins.llm.judge.llmclient import LLMClient
@@ -39,24 +62,30 @@ class TestLLMJudgePlugin(TestCase):
         self.assertEqual(plugin.client, LLMClient)
 
 
-@skipUnless(_has_langchain, 'langchain-anthropic not installed')
-class TestLLMClient(TestCase):
-    """Tests for LLMClient (langchain-anthropic based LLM judge)."""
+@skipUnless(_has_langchain_openai, 'langchain-openai not installed')
+class TestLLMClientOpenAI(TestCase):
+    """Tests for LLMClient with OpenAI provider (default)."""
 
-    @patch('taf.foundation.plugins.llm.judge.llmclient.ChatAnthropic')
-    def test_init_default_model(self, mock_chat):
+    @patch('langchain_openai.ChatOpenAI')
+    def test_default_provider_is_openai(self, mock_chat):
         from taf.foundation.plugins.llm.judge.llmclient import LLMClient
         client = LLMClient()
         mock_chat.assert_called_once()
-        self.assertEqual(len(client.rubric), 5)
+        self.assertEqual(client.provider, 'openai')
+        self.assertEqual(client.model, 'gpt-4o-mini')
 
-    @patch('taf.foundation.plugins.llm.judge.llmclient.ChatAnthropic')
-    def test_init_custom_model(self, mock_chat):
+    @patch('langchain_openai.ChatOpenAI')
+    def test_custom_base_url(self, mock_chat):
         from taf.foundation.plugins.llm.judge.llmclient import LLMClient
-        client = LLMClient(model='claude-3-haiku-20240307')
-        self.assertEqual(client.model, 'claude-3-haiku-20240307')
+        client = LLMClient(
+            base_url='http://localhost:11434/v1',
+            model='llama3',
+        )
+        call_kwargs = mock_chat.call_args[1]
+        self.assertEqual(call_kwargs['base_url'], 'http://localhost:11434/v1')
+        self.assertEqual(client.model, 'llama3')
 
-    @patch('taf.foundation.plugins.llm.judge.llmclient.ChatAnthropic')
+    @patch('langchain_openai.ChatOpenAI')
     def test_score(self, mock_chat):
         from taf.foundation.plugins.llm.judge.llmclient import LLMClient
 
@@ -69,23 +98,8 @@ class TestLLMClient(TestCase):
         client = LLMClient()
         score = client.score('What is 2+2?', 'The answer is 4.', 'accuracy')
         self.assertEqual(score, 4.5)
-        mock_llm.invoke.assert_called_once()
 
-    @patch('taf.foundation.plugins.llm.judge.llmclient.ChatAnthropic')
-    def test_score_invalid_response_returns_default(self, mock_chat):
-        from taf.foundation.plugins.llm.judge.llmclient import LLMClient
-
-        mock_llm = MagicMock()
-        mock_result = MagicMock()
-        mock_result.content = 'not json'
-        mock_llm.invoke.return_value = mock_result
-        mock_chat.return_value = mock_llm
-
-        client = LLMClient()
-        score = client.score('prompt', 'response', 'accuracy')
-        self.assertEqual(score, 3.0)
-
-    @patch('taf.foundation.plugins.llm.judge.llmclient.ChatAnthropic')
+    @patch('langchain_openai.ChatOpenAI')
     def test_evaluate_all_dimensions(self, mock_chat):
         from taf.foundation.plugins.llm.judge.llmclient import LLMClient
 
@@ -99,10 +113,58 @@ class TestLLMClient(TestCase):
         scores = client.evaluate('prompt', 'response')
 
         self.assertEqual(len(scores), 6)  # 5 dimensions + overall
-        self.assertIn('accuracy', scores)
-        self.assertIn('completeness', scores)
-        self.assertIn('relevance', scores)
-        self.assertIn('clarity', scores)
-        self.assertIn('safety', scores)
         self.assertIn('overall', scores)
         self.assertEqual(scores['overall'], 4.0)
+
+    @patch('langchain_openai.ChatOpenAI')
+    def test_score_invalid_response_returns_default(self, mock_chat):
+        from taf.foundation.plugins.llm.judge.llmclient import LLMClient
+
+        mock_llm = MagicMock()
+        mock_result = MagicMock()
+        mock_result.content = 'not json'
+        mock_llm.invoke.return_value = mock_result
+        mock_chat.return_value = mock_llm
+
+        client = LLMClient()
+        score = client.score('prompt', 'response', 'accuracy')
+        self.assertEqual(score, 3.0)
+
+
+@skipUnless(_has_langchain_anthropic, 'langchain-anthropic not installed')
+class TestLLMClientAnthropic(TestCase):
+    """Tests for LLMClient with Anthropic provider."""
+
+    @patch('langchain_anthropic.ChatAnthropic')
+    def test_anthropic_provider(self, mock_chat):
+        from taf.foundation.plugins.llm.judge.llmclient import LLMClient
+        client = LLMClient(provider='anthropic')
+        mock_chat.assert_called_once()
+        self.assertEqual(client.provider, 'anthropic')
+        self.assertEqual(client.model, 'claude-sonnet-4-20250514')
+
+    @patch('langchain_anthropic.ChatAnthropic')
+    def test_anthropic_score(self, mock_chat):
+        from taf.foundation.plugins.llm.judge.llmclient import LLMClient
+
+        mock_llm = MagicMock()
+        mock_result = MagicMock()
+        mock_result.content = '{"score": 4.0, "reason": "ok"}'
+        mock_llm.invoke.return_value = mock_result
+        mock_chat.return_value = mock_llm
+
+        client = LLMClient(provider='anthropic')
+        score = client.score('prompt', 'response', 'accuracy')
+        self.assertEqual(score, 4.0)
+
+
+@skipUnless(_has_langchain_openai, 'langchain-openai not installed')
+class TestLLMClientEnvOverride(TestCase):
+    """Tests for TAF_LLM_PROVIDER env var override."""
+
+    @patch('langchain_openai.ChatOpenAI')
+    @patch.dict('os.environ', {'TAF_LLM_PROVIDER': 'openai'})
+    def test_env_var_openai(self, mock_chat):
+        from taf.foundation.plugins.llm.judge.llmclient import LLMClient
+        client = LLMClient()
+        self.assertEqual(client.provider, 'openai')

--- a/src/test/python/ut/test_modeling_extensions.py
+++ b/src/test/python/ut/test_modeling_extensions.py
@@ -1,0 +1,184 @@
+# Copyright (c) 2017-2026 Wesley Peng
+#
+# Licensed under the GNU Lesser General Public License v3.0 (LGPL-3.0).
+# You may obtain a copy of the License at
+#
+# https://www.gnu.org/licenses/lgpl-3.0.html
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+
+from unittest import TestCase
+from unittest.mock import MagicMock
+
+from taf.modeling.ws.wsclient import WSClient
+from taf.modeling.llm.llmjudge import LLMJudge
+
+
+class TestWSClientModeling(TestCase):
+    """Tests for WSClient modeling layer enhancements."""
+
+    def test_collect_returns_messages(self):
+        client = WSClient('ws://localhost:8080')
+        client._connection = MagicMock()
+
+        responses = iter(['msg1', 'msg2', 'msg3'])
+
+        def mock_receive(timeout=None):
+            try:
+                return next(responses)
+            except StopIteration:
+                raise TimeoutError()
+
+        client.receive = mock_receive
+        messages = client.collect(timeout=1)
+        self.assertEqual(messages, ['msg1', 'msg2', 'msg3'])
+
+    def test_collect_text_concatenates(self):
+        client = WSClient('ws://localhost:8080')
+        client._connection = MagicMock()
+
+        responses = iter(['Hello', ' ', 'World'])
+
+        def mock_receive(timeout=None):
+            try:
+                return next(responses)
+            except StopIteration:
+                raise TimeoutError()
+
+        client.receive = mock_receive
+        text = client.collect_text(timeout=1)
+        self.assertEqual(text, 'Hello World')
+
+    def test_collect_text_with_separator(self):
+        client = WSClient('ws://localhost:8080')
+        client._connection = MagicMock()
+
+        responses = iter(['line1', 'line2'])
+
+        def mock_receive(timeout=None):
+            try:
+                return next(responses)
+            except StopIteration:
+                raise TimeoutError()
+
+        client.receive = mock_receive
+        text = client.collect_text(timeout=1, separator='\n')
+        self.assertEqual(text, 'line1\nline2')
+
+    def test_collect_respects_max_messages(self):
+        client = WSClient('ws://localhost:8080')
+        client._connection = MagicMock()
+
+        call_count = 0
+
+        def mock_receive(timeout=None):
+            nonlocal call_count
+            call_count += 1
+            return f'msg{call_count}'
+
+        client.receive = mock_receive
+        messages = client.collect(timeout=1, max_messages=2)
+        self.assertEqual(len(messages), 2)
+
+    def test_send_and_receive(self):
+        client = WSClient('ws://localhost:8080')
+        client._connection = MagicMock()
+        client.send = MagicMock()
+        client.receive = MagicMock(return_value='pong')
+
+        result = client.send_and_receive('ping')
+        client.send.assert_called_once_with('ping')
+        self.assertEqual(result, 'pong')
+
+    def test_collect_empty_on_immediate_timeout(self):
+        client = WSClient('ws://localhost:8080')
+        client._connection = MagicMock()
+
+        def mock_receive(timeout=None):
+            raise TimeoutError()
+
+        client.receive = mock_receive
+        messages = client.collect(timeout=0.01)
+        self.assertEqual(messages, [])
+
+
+class TestLLMJudgeModeling(TestCase):
+    """Tests for LLMJudge modeling layer enhancements."""
+
+    def test_assert_quality_passes(self):
+        judge = LLMJudge()
+        judge.evaluate = MagicMock(return_value={
+            'accuracy': 4.5, 'completeness': 4.0,
+            'relevance': 4.0, 'clarity': 4.0,
+            'safety': 5.0, 'overall': 4.3,
+        })
+
+        result = judge.assert_quality('prompt', 'response')
+        self.assertTrue(result['passed'])
+        self.assertEqual(result['overall'], 4.3)
+
+    def test_assert_quality_fails_overall(self):
+        judge = LLMJudge()
+        judge.evaluate = MagicMock(return_value={
+            'accuracy': 2.0, 'completeness': 2.0,
+            'relevance': 2.0, 'clarity': 2.0,
+            'safety': 2.0, 'overall': 2.0,
+        })
+
+        with self.assertRaises(AssertionError) as ctx:
+            judge.assert_quality('prompt', 'response')
+        self.assertIn('overall 2.00 < 3.5', str(ctx.exception))
+
+    def test_assert_quality_fails_floor(self):
+        judge = LLMJudge()
+        judge.evaluate = MagicMock(return_value={
+            'accuracy': 1.5, 'completeness': 4.0,
+            'relevance': 4.0, 'clarity': 4.0,
+            'safety': 4.0, 'overall': 3.5,
+        })
+
+        with self.assertRaises(AssertionError) as ctx:
+            judge.assert_quality(
+                'prompt', 'response', fail_any_below=2.0
+            )
+        self.assertIn('accuracy 1.50 < 2.0 (floor)', str(ctx.exception))
+
+    def test_assert_quality_fails_dimension_threshold(self):
+        judge = LLMJudge()
+        judge.evaluate = MagicMock(return_value={
+            'accuracy': 3.5, 'completeness': 4.0,
+            'relevance': 4.0, 'clarity': 4.0,
+            'safety': 4.0, 'overall': 3.9,
+        })
+
+        with self.assertRaises(AssertionError) as ctx:
+            judge.assert_quality(
+                'prompt', 'response',
+                dimension_thresholds={'accuracy': 4.0},
+            )
+        self.assertIn('accuracy 3.50 < 4.0', str(ctx.exception))
+
+    def test_assert_quality_no_floor(self):
+        judge = LLMJudge()
+        judge.evaluate = MagicMock(return_value={
+            'accuracy': 1.0, 'completeness': 5.0,
+            'relevance': 5.0, 'clarity': 5.0,
+            'safety': 5.0, 'overall': 4.2,
+        })
+
+        result = judge.assert_quality(
+            'prompt', 'response', fail_any_below=None
+        )
+        self.assertTrue(result['passed'])
+
+    def test_provider_passthrough(self):
+        judge = LLMJudge(provider='anthropic', model='claude-3-haiku')
+        self.assertEqual(judge.provider, 'anthropic')
+        self.assertEqual(judge.model, 'claude-3-haiku')
+
+    def test_base_url_passthrough(self):
+        judge = LLMJudge(base_url='http://localhost:11434/v1')
+        self.assertEqual(judge.base_url, 'http://localhost:11434/v1')


### PR DESCRIPTION
## T.1.4 — Modeling Layer Extensions

### LLM Provider Agnosticism
- Decoupled LLMClient from ChatAnthropic — now supports `provider=openai` (default, works with OpenAI/OpenRouter/local LLMs) and `provider=anthropic`
- Lazy imports, TAF_LLM_PROVIDER env var, base_url/api_key kwargs
- pyproject.toml: llm group defaults to langchain-openai; llm-anthropic and llm-all groups added

### WSClient Streaming
- `collect()` batch receive, `collect_text()` concatenate, `send_and_receive()` request-response

### LLMJudge Thresholds
- `assert_quality()` with overall_threshold, dimension_thresholds, fail_any_below — raises AssertionError on failure

### Tests
- 20 new (109 total). LLM tests cover both OpenAI and Anthropic providers.
- flake8 0, mypy 0 (141 files), pytest 109 passed (local) / 98+11 skipped (CI)