### PR TITLE
refactor: OCP provider factory for LLM client; document test framework TLS defaults

### DIFF
--- a/src/main/python/taf/foundation/plugins/llm/judge/llmclient.py
+++ b/src/main/python/taf/foundation/plugins/llm/judge/llmclient.py
@@ -12,39 +12,48 @@
 
 import json
 import os
-from typing import Any
+from typing import Any, Callable
 
 from taf.foundation.api.llm import Client
 
 
-def _create_chat_model(
-        provider: str,
+# --- Provider registry (OCP-compliant factory) -------------------------------
+#
+# Each provider is a callable ``(model, base_url, api_key, **kwargs) -> Any``
+# that returns a LangChain chat model instance. Register new providers via
+# ``register_provider()`` instead of editing this file — adding a new provider
+# does not require modifying ``_create_chat_model`` (Open/Closed Principle).
+#
+# Lazy imports inside each builder keep optional SDK dependencies optional:
+# only the provider actually requested is imported at runtime.
+
+_ProviderBuilder = Callable[..., Any]
+_PROVIDER_REGISTRY: dict[str, _ProviderBuilder] = {}
+
+
+def register_provider(name: str, builder: _ProviderBuilder) -> None:
+    """Register a new chat-model provider.
+
+    Args:
+        name: Provider identifier (e.g., ``'openai'``, ``'anthropic'``,
+            ``'ollama'``). Should match the value used in
+            ``Client.PROVIDER_*`` constants or the ``TAF_LLM_PROVIDER``
+            environment variable.
+        builder: Callable with signature
+            ``(model, base_url, api_key, **kwargs) -> BaseChatModel``.
+    """
+    _PROVIDER_REGISTRY[name] = builder
+
+
+def _build_openai(
         model: str,
         base_url: str | None = None,
         api_key: str | None = None,
         **kwargs
 ) -> Any:
-    """Create a LangChain chat model based on provider.
-
-    Supports:
-      - 'openai': langchain-openai ChatOpenAI (also works with
-        OpenAI-compatible APIs like local LLMs, OpenRouter, vLLM)
-      - 'anthropic': langchain-anthropic ChatAnthropic
-    """
-    if provider == Client.PROVIDER_ANTHROPIC:
-        from langchain_anthropic import ChatAnthropic
-        init_kwargs: dict[str, Any] = {
-            'model_name': model,
-            'temperature': kwargs.get('temperature', 0.0),
-        }
-        if api_key:
-            init_kwargs['anthropic_api_key'] = api_key
-        return ChatAnthropic(**init_kwargs)
-
-    # Default: OpenAI-compatible (works with OpenAI, OpenRouter,
-    # local LLMs, vLLM, etc.)
+    """OpenAI-compatible chat model (OpenAI, OpenRouter, Ollama, vLLM, ...)."""
     from langchain_openai import ChatOpenAI
-    init_kwargs = {
+    init_kwargs: dict[str, Any] = {
         'model': model,
         'temperature': kwargs.get('temperature', 0.0),
         'max_tokens': kwargs.get('max_tokens', 1024),
@@ -54,6 +63,51 @@ def _create_chat_model(
     if api_key:
         init_kwargs['api_key'] = api_key
     return ChatOpenAI(**init_kwargs)
+
+
+def _build_anthropic(
+        model: str,
+        base_url: str | None = None,
+        api_key: str | None = None,
+        **kwargs
+) -> Any:
+    """Anthropic Claude chat model (native Messages API, not OpenAI-compat)."""
+    from langchain_anthropic import ChatAnthropic
+    init_kwargs: dict[str, Any] = {
+        'model_name': model,
+        'temperature': kwargs.get('temperature', 0.0),
+    }
+    if api_key:
+        init_kwargs['anthropic_api_key'] = api_key
+    return ChatAnthropic(**init_kwargs)
+
+
+# Register the two built-in providers. New providers can be added at runtime
+# (e.g., from a plugin) by calling ``register_provider()`` without modifying
+# this module — that's the OCP win.
+register_provider(Client.PROVIDER_OPENAI, _build_openai)
+register_provider(Client.PROVIDER_ANTHROPIC, _build_anthropic)
+
+
+def _create_chat_model(
+        provider: str,
+        model: str,
+        base_url: str | None = None,
+        api_key: str | None = None,
+        **kwargs
+) -> Any:
+    """Create a LangChain chat model for the named provider.
+
+    Falls back to the OpenAI-compatible builder when the provider is not
+    registered, preserving the prior default behaviour.
+    """
+    builder = _PROVIDER_REGISTRY.get(provider, _build_openai)
+    return builder(
+        model,
+        base_url=base_url,
+        api_key=api_key,
+        **kwargs,
+    )
 
 
 class LLMClient(Client):

--- a/src/main/python/taf/foundation/plugins/svc/httpx/httpclient.py
+++ b/src/main/python/taf/foundation/plugins/svc/httpx/httpclient.py
@@ -16,6 +16,22 @@ from taf.foundation.api.svc.REST import Client
 
 
 class HttpClient(Client):
+    """httpx-backed REST client for the test automation framework.
+
+    TLS verification defaults to ``False`` because Agentic-TAF targets
+    test environments that frequently use self-signed certificates
+    (preprod kubeadm clusters, in-cluster service URLs, lab vCenters).
+    Production-grade callers can override by passing ``verify=`` to the
+    constructor:
+
+        HttpClient(url, verify=True)                  # system trust store
+        HttpClient(url, verify='/path/to/ca.pem')     # custom CA bundle
+        HttpClient(url, verify=False)                 # explicit (default)
+
+    See ``docs/architecture.md`` and the platform's
+    ``docs/07-security-access-control.md`` for guidance on production usage.
+    """
+
     def __init__(
             self,
             base_url,
@@ -25,6 +41,8 @@ class HttpClient(Client):
             **kwargs
     ):
         headers = kwargs.pop('headers', None)
+        # Caller may override TLS verification; preserve test-friendly default.
+        verify = kwargs.pop('verify', False)
 
         super().__init__(
             base_url, port,
@@ -39,7 +57,7 @@ class HttpClient(Client):
             base_url=self.params.get('url', ''),
             auth=auth,
             headers=headers,
-            verify=False,
+            verify=verify,
             timeout=kwargs.get('timeout', 60.0),
         )
 

--- a/src/main/python/taf/foundation/plugins/svc/requests/restclient.py
+++ b/src/main/python/taf/foundation/plugins/svc/requests/restclient.py
@@ -18,6 +18,22 @@ from taf.foundation.api.svc.REST import Client
 
 
 class RESTClient(Session, Client):  # type: ignore[misc]
+    """requests-backed REST client for the test automation framework.
+
+    TLS verification defaults to ``False`` because Agentic-TAF targets
+    test environments that frequently use self-signed certificates
+    (preprod kubeadm clusters, in-cluster service URLs, lab vCenters).
+    Production-grade callers can override by passing ``verify=`` to the
+    constructor:
+
+        RESTClient(url, verify=True)                # system trust store
+        RESTClient(url, verify='/path/to/ca.pem')   # custom CA bundle
+        RESTClient(url, verify=False)               # explicit (default)
+
+    See ``docs/architecture.md`` and the platform's
+    ``docs/07-security-access-control.md`` for guidance on production usage.
+    """
+
     def __init__(
             self,
             base_url,
@@ -28,18 +44,25 @@ class RESTClient(Session, Client):  # type: ignore[misc]
     ):
         Session.__init__(self)
 
+        # Caller may override TLS verification; preserve test-friendly default.
+        verify = kwargs.pop('verify', False)
+
         Client.__init__(
             self, base_url, port,
             username, password, **kwargs
         )
 
-        self.verify = False
+        self.verify = verify
 
         self._set_auth(
             username, password
         )
 
-        urllib3.disable_warnings()
+        # Only suppress warnings when verification is intentionally
+        # disabled — caller opting in to verification deserves the
+        # default warning behaviour.
+        if verify is False:
+            urllib3.disable_warnings()
 
     def get(self, url, **kwargs):  # type: ignore[override]
         return Session.get(

--- a/src/test/python/ut/test_llm_plugin.py
+++ b/src/test/python/ut/test_llm_plugin.py
@@ -168,3 +168,57 @@ class TestLLMClientEnvOverride(TestCase):
         from taf.foundation.plugins.llm.judge.llmclient import LLMClient
         client = LLMClient()
         self.assertEqual(client.provider, 'openai')
+
+
+class TestProviderRegistry(TestCase):
+    """Tests for the OCP-compliant provider factory registry."""
+
+    def test_register_provider_extends_factory(self):
+        """A new provider can be registered without modifying _create_chat_model."""
+        from taf.foundation.plugins.llm.judge import llmclient
+
+        captured: dict = {}
+
+        def stub_builder(model, base_url=None, api_key=None, **kwargs):
+            captured['model'] = model
+            captured['base_url'] = base_url
+            captured['api_key'] = api_key
+            captured['kwargs'] = kwargs
+            return MagicMock(name='StubChat')
+
+        original = llmclient._PROVIDER_REGISTRY.copy()
+        try:
+            llmclient.register_provider('stub-provider', stub_builder)
+            result = llmclient._create_chat_model(
+                provider='stub-provider',
+                model='dummy-model',
+                base_url='http://example.invalid',
+                api_key='secret-key',
+                temperature=0.7,
+            )
+            self.assertIsNotNone(result)
+            self.assertEqual(captured['model'], 'dummy-model')
+            self.assertEqual(captured['base_url'], 'http://example.invalid')
+            self.assertEqual(captured['api_key'], 'secret-key')
+            self.assertEqual(captured['kwargs'].get('temperature'), 0.7)
+        finally:
+            llmclient._PROVIDER_REGISTRY.clear()
+            llmclient._PROVIDER_REGISTRY.update(original)
+
+    def test_unknown_provider_falls_back_to_openai(self):
+        """Unknown provider names route to the OpenAI-compatible builder."""
+        from taf.foundation.plugins.llm.judge import llmclient
+
+        with patch.object(llmclient, '_build_openai') as mock_openai:
+            mock_openai.return_value = MagicMock(name='OpenAIChat')
+            llmclient._create_chat_model(
+                provider='nonexistent',
+                model='gpt-4o-mini',
+            )
+            mock_openai.assert_called_once()
+
+    def test_builtin_providers_registered_at_import(self):
+        """openai and anthropic are registered on module import."""
+        from taf.foundation.plugins.llm.judge import llmclient
+        self.assertIn(LLMBaseClient.PROVIDER_OPENAI, llmclient._PROVIDER_REGISTRY)
+        self.assertIn(LLMBaseClient.PROVIDER_ANTHROPIC, llmclient._PROVIDER_REGISTRY)


### PR DESCRIPTION
## Summary

Two audit findings addressed in a single small PR.

### 1. OCP refactor — `_create_chat_model` provider factory

Was: `if/elif` on provider type (modify-to-extend, OCP violation).

Now: module-level `_PROVIDER_REGISTRY` + `register_provider(name, builder)` API. New providers (Ollama-native, vLLM-native, ...) can be added at runtime without editing `_create_chat_model`.

```python
from taf.foundation.plugins.llm.judge.llmclient import register_provider

def _build_ollama_native(model, base_url=None, api_key=None, **kwargs):
    from langchain_community.chat_models import ChatOllama
    return ChatOllama(model=model, base_url=base_url, **kwargs)

register_provider('ollama', _build_ollama_native)
```

Lazy imports preserved (each builder imports its SDK only when invoked). Public API unchanged — same kwargs, same return types, same defaults.

### 2. Document test framework `verify=False`

The security audit flagged HIGH-severity `verify=False` in `HttpClient` and `RESTClient`. Behaviour is **intentional** (Agentic-TAF targets self-signed test environments), but was undocumented and not overridable.

Fix: explicit class docstrings + caller-overridable `verify` kwarg.

```python
client = RESTClient(url)                       # verify=False (default — test env)
client = RESTClient(url, verify=True)          # production with system trust store
client = RESTClient(url, verify='/ca.pem')     # custom CA bundle
```

`urllib3.disable_warnings()` in RESTClient now only fires when verification is intentionally disabled.

## Validation

```
flake8 src/ --max-line-length=120         → 0 issues
mypy src/main/python/taf/                 → 152 files, 0 issues
pytest src/test/python/ut/                → 274 passed (271 baseline + 3 new)
```

The 3 new unit tests in `TestProviderRegistry` cover: registry extension, unknown-provider fallback, built-in registration at import.

## Design Principles

- **SOLID OCP**: provider extension via registration, not modification
- **SOLID DIP**: callers depend on provider string, not concrete classes
- **KISS**: single dict lookup; no factory-of-factory
- **SoC**: builder per provider (one reason to change each)
- **Backward compatible**: same public API, same defaults, same return types

## Note on Test Count

This branch was cut from `main` before PR #48 (T.10) merged. After both this PR and #48 land, total unit tests will be 277 (271 baseline + 3 from #48 + 3 from this PR). I'll bump the doc count after both merges.